### PR TITLE
Update Button.swift

### DIFF
--- a/Sources/SwiftHtml/Tags/Button.swift
+++ b/Sources/SwiftHtml/Tags/Button.swift
@@ -13,9 +13,13 @@
 ///
 /// **Tip:** You can easily style buttons with CSS! Look at the examples below or visit our CSS Buttons tutorial.
 open class Button: Tag {
+    
+    public init(_ contents: String? = nil, @TagBuilder _ builder: () -> [Tag]) {
+        super.init(Node(type: .standard, name: "button", contents: contents), children: builder())
+    }
 
-    public init(_ contents: String) {
-        super.init(Node(type: .standard, name: "button", contents: contents))
+    public convenience init(_ contents: String) {
+        self.init(contents) {}
     }
 }
 


### PR DESCRIPTION
When using libraries like Bootstrap, I often need to put child elements inside buttons. But the init() only takes contents.

Not sure if it was intentional. To only allow users to create Buttons with String contents. But I would think all Tags should have a designated init() that allows for children with a builder parameter, whether or not it produces well written HTML. And then the convenience inits would implement preferred or common usage. Like in A.swift where the convenience init() just takes contents.