### PR TITLE
Update Global.swift

### DIFF
--- a/Sources/SwiftHtml/Attributes/Global.swift
+++ b/Sources/SwiftHtml/Attributes/Global.swift
@@ -56,7 +56,7 @@ public extension Tag {
     /// Specifies multiple classnames for an element (refers to a class in a style sheet)
     func `class`(_ values: [String], _ condition: Bool = true) -> Self {
         /// @NOTE: explicit true flag is needed, otherwise Swift won't know which function to call...
-        `class`(values.joined(separator: " "), condition)
+        `class`(values.filter{$0.count > 0}.joined(separator: " "), condition)
     }
 
     /// Specifies multiple classnames for an element (refers to a class in a style sheet)

--- a/Sources/SwiftHtml/Attributes/Global.swift
+++ b/Sources/SwiftHtml/Attributes/Global.swift
@@ -56,7 +56,7 @@ public extension Tag {
     /// Specifies multiple classnames for an element (refers to a class in a style sheet)
     func `class`(_ values: [String], _ condition: Bool = true) -> Self {
         /// @NOTE: explicit true flag is needed, otherwise Swift won't know which function to call...
-        `class`(values.filter{$0.count > 0}.joined(separator: " "), condition)
+        `class`(values.filter{!$0.isEmpty}.joined(separator: " "), condition)
     }
 
     /// Specifies multiple classnames for an element (refers to a class in a style sheet)


### PR DESCRIPTION
Eliminate empty strings from array before joining. Otherwise the final value may contain extra spaces.

let strings = ["1", "", "2", "3", ""]

let str = strings.joined(separator: " ") // => "1 23 "

let str2 = strings.filter{$0.count > 0}.joined(separator: " ") // => "123"