### PR TITLE
Update Tag.swift

### DIFF
--- a/Sources/SwiftSgml/Tag.swift
+++ b/Sources/SwiftSgml/Tag.swift
@@ -16,23 +16,18 @@ open class Tag {
         Node(type: .standard, name: String(describing: self).lowercased())
     }
 
-    /// initialize a new Tag with child tags
-    public init(_ children: [Tag] = []) {
+    /// initialize a new Tag with contents and child tags
+    public init(_ contents: String? = nil, _ children: [Tag] = []) {
         self.node = Self.createNode()
         self.children = children
+        if let contents = contents {
+             setContents(contents) 
+        }
     }
     
     /// initialize a new Tag with children using a builder
     public convenience init(@TagBuilder _ builder: () -> [Tag]) {
         self.init(builder())
-    }
-
-    /// initialize a new Tag with some contents
-    public convenience init(_ contents: String?) {
-        self.init()
-        if let contents = contents {
-            setContents(contents)
-        }
     }
 
     // MARK: - contents


### PR DESCRIPTION
Is there a reason the required init can't take both contents: String? and children: [Tag]?

So typography tags can be more readable?

For example:

` <H4>Some text before a <span>styled text</span> and more after</H4>`

Could be written...

H4("Some text before a") {
     Span("styled text")
     Text("and more after")
}