### PR TITLE
Update Tag.swift

### DIFF
--- a/Sources/SwiftSgml/Tag.swift
+++ b/Sources/SwiftSgml/Tag.swift
@@ -17,7 +17,7 @@ open class Tag {
     }
 
     /// initialize a new Tag with child tags
-    public init(_ children: [Tag] = []) {
+    public required init(_ children: [Tag] = []) {
         self.node = Self.createNode()
         self.children = children
     }


### PR DESCRIPTION
Just a thought...

I tried using Tag with generics.

Got this compiler error...

Constructing an object of class type ’T’ with a metatype value must use a ‘required’ initializer

Example:

public class MyClass<T: Tag> {

    let props: MyProps
    let children: [Tag]

    init(_ props: MyProps, @TagBuilder _ children: () -> [Tag]) {
        self.props = props
        self.children = children()
    }

    public func build() -> Tag {
        T(children)
            .doSomething(props)
            .anotherThing(props)
    }
}