### PR TITLE
Update Global.swift

### DIFF
--- a/Sources/SwiftHtml/Attributes/Global.swift
+++ b/Sources/SwiftHtml/Attributes/Global.swift
@@ -107,7 +107,7 @@ public extension Tag {
     /// Removes an array of class values if the condition is true
     func `class`(remove values: [String], _ condition: Bool = true) -> Self {
         let newClasses = classArray.filter { !values.contains($0) }
-        if newClasses.count == 0 {
+        if newClasses.isEmpty {
             return deleteAttribute("class")
         }
         return `class`(newClasses, condition)

--- a/Sources/SwiftHtml/Attributes/Global.swift
+++ b/Sources/SwiftHtml/Attributes/Global.swift
@@ -107,6 +107,9 @@ public extension Tag {
     /// Removes an array of class values if the condition is true
     func `class`(remove values: [String], _ condition: Bool = true) -> Self {
         let newClasses = classArray.filter { !values.contains($0) }
+        if newClasses.count == 0 {
+            return deleteAttribute("class")
+        }
         return `class`(newClasses, condition)
     }
     

--- a/Tests/SwiftHtmlTests/SwiftHtmlTests.swift
+++ b/Tests/SwiftHtmlTests/SwiftHtmlTests.swift
@@ -82,6 +82,16 @@ final class SwiftHtmlTests: XCTestCase {
         XCTAssertEqual(#"<span class="a c"></span>"#, html)
     }
     
+    func testRemoveLastClass() {
+        let doc = Document {
+            Span("")
+                .class("a")
+                .class(remove: "a")
+        }
+        let html = DocumentRenderer(minify: true).render(doc)
+        XCTAssertEqual(#"<span></span>"#, html)
+    }
+    
     func testToggleAddClass() {
         let doc = Document {
             Span("")


### PR DESCRIPTION
Shouldn't the class attribute be deleted after the last value is removed?

Otherwise you get...

<Tag class=""></Tag>