### PR TITLE
Update Textarea.swift

### DIFF
--- a/Sources/SwiftHtml/Tags/Textarea.swift
+++ b/Sources/SwiftHtml/Tags/Textarea.swift
@@ -48,7 +48,7 @@ public extension Textarea {
     
     /// Specifies that a text area should be disabled
     func disabled(_ condition: Bool = true) -> Self {
-        flagAttribute("autofocus", nil, condition)
+        flagAttribute("disabled", nil, condition)
     }
     
     /// Specifies which form the text area belongs to


### PR DESCRIPTION
Textarea bug: attribute value for disabled should be "disabled" and not "autofocus"

Tibor, this is the first time ever that I make a code change in Github. I hope, I do it correctly. Please check. Thx