### PR TITLE
Treat class attribute value like Set<String>

### DIFF
--- a/Sources/SwiftHtml/Attributes/Global.swift
+++ b/Sources/SwiftHtml/Attributes/Global.swift
@@ -71,23 +71,36 @@ public extension Tag {
         `class`(values)
     }
     
-    /// Adds a single value to the class list if the condition is true
+    /// Inserts a single value to the class list if the condition is true
     ///
-    /// Note: If the value is empty or nil it won't be added to the list
+    /// Note: If the value is empty or nil it won't be inserted to the list
     ///
-    func `class`(add value: String?, _ condition: Bool = true) -> Self {
+    func `class`(insert value: String?, _ condition: Bool = true) -> Self {
         guard let value = value else {
             return self
         }
-        return `class`(add: [value], condition)
+        return `class`(insert: [value], condition)
     }
     
-    /// Adds an array of values to the class list if the condition is true
+    /// Inserts a variadic array of optional values to the class list if the condition is true
     ///
-    /// Note: If the value is empty it won't be added to the list
+    /// Note: nil or empty values will not be inserted into the list
     ///
-    func `class`(add values: [String], _ condition: Bool = true) -> Self {
-        let newValues = classArray + values.filter { !$0.isEmpty }
+    func `class`(insert values: String?..., if condition: Bool = true) -> Self {
+        return `class`(insert: values, condition)
+    }
+    
+     /// Inserts an array of values to the class list if the condition is true
+    ///
+    /// Note: If the value is empty it won't be inserted into the list
+    ///
+    func `class`(insert values: [String?], _ condition: Bool = true) -> Self {
+        let values = values.compactMap{ $0 }.filter{ !$0.isEmpty }
+        guard condition, !values.isEmpty else { return self }
+        
+        var classes = Set(classArray)
+        _ = values.map{ classes.insert($0) }
+        let newValues = Array(classes)
 
         var newValue: String? = nil
         if !newValues.isEmpty {

--- a/Sources/SwiftHtml/Attributes/Global.swift
+++ b/Sources/SwiftHtml/Attributes/Global.swift
@@ -137,7 +137,7 @@ public extension Tag {
         if classArray.contains(value) {
             return `class`(remove: value, condition)
         }
-        return `class`(add: value, condition)
+        return `class`(insert: value, condition)
     }
     
     // MARK: - other global attributes

--- a/Sources/SwiftHtml/Attributes/Global.swift
+++ b/Sources/SwiftHtml/Attributes/Global.swift
@@ -119,6 +119,7 @@ public extension Tag {
     
     /// Removes an array of class values if the condition is true
     func `class`(remove values: [String], _ condition: Bool = true) -> Self {
+        guard condition else { return self }
         let newClasses = classArray.filter { !values.contains($0) }
         if newClasses.isEmpty {
             return deleteAttribute("class")

--- a/Sources/SwiftHtml/Attributes/Global.swift
+++ b/Sources/SwiftHtml/Attributes/Global.swift
@@ -98,17 +98,14 @@ public extension Tag {
     func `class`(insert values: [String]?, _ condition: Bool = true) -> Self {
         guard condition, let values = values?.filter({!$0.isEmpty}), !values.isEmpty else {
             return self
+        }        
+        var classes = Array(classArray)
+        for value in values {
+            if !classes.contains(value) {
+                classes.append(value)
+            }
         }
-        
-        var classes = Set(classArray)
-        _ = values.map{ classes.insert($0) }
-        let newValues = Array(classes)
-
-        var newValue: String? = nil
-        if !newValues.isEmpty {
-            newValue = newValues.classString
-        }
-        return `class`(newValue, condition)
+        return `class`(classes.classString, condition)
     }
     
     /// Removes a given class values if the condition is true

--- a/Sources/SwiftHtml/Attributes/Global.swift
+++ b/Sources/SwiftHtml/Attributes/Global.swift
@@ -87,6 +87,7 @@ public extension Tag {
     /// Note: nil or empty values will not be inserted into the list
     ///
     func `class`(insert values: String?..., if condition: Bool = true) -> Self {
+        let values = values.compactMap{ $0 }
         return `class`(insert: values, condition)
     }
     
@@ -94,9 +95,10 @@ public extension Tag {
     ///
     /// Note: If the value is empty it won't be inserted into the list
     ///
-    func `class`(insert values: [String?], _ condition: Bool = true) -> Self {
-        let values = values.compactMap{ $0 }.filter{ !$0.isEmpty }
-        guard condition, !values.isEmpty else { return self }
+    func `class`(insert values: [String]?, _ condition: Bool = true) -> Self {
+        guard condition, let values = values?.filter({!$0.isEmpty}), !values.isEmpty else {
+            return self
+        }
         
         var classes = Set(classArray)
         _ = values.map{ classes.insert($0) }

--- a/Tests/SwiftHtmlTests/SwiftHtmlTests.swift
+++ b/Tests/SwiftHtmlTests/SwiftHtmlTests.swift
@@ -53,8 +53,8 @@ final class SwiftHtmlTests: XCTestCase {
         let doc = Document {
             Span("")
                 .class("a", "b", "c")
-                .class(add: ["d", "e", "f"])
-                .class(add: "b", true)
+                .class(insert: ["d", "e", "f"])
+                .class(insert: "b", true)
                 .class(remove: ["b", "c", "d"])
                 .class(remove: "e", true)
         }
@@ -66,7 +66,7 @@ final class SwiftHtmlTests: XCTestCase {
         let doc = Document {
             Span("")
                 .class("a", "b", "c")
-                .class(add: "d")
+                .class(insert: "d")
         }
         let html = DocumentRenderer(minify: true).render(doc)
         XCTAssertEqual(#"<span class="a b c d"></span>"#, html)

--- a/Tests/SwiftHtmlTests/SwiftHtmlTests.swift
+++ b/Tests/SwiftHtmlTests/SwiftHtmlTests.swift
@@ -62,10 +62,11 @@ final class SwiftHtmlTests: XCTestCase {
         XCTAssertEqual(#"<span class="a f"></span>"#, html)
     }
     
-    func testAddClass() {
+    func testInsertClass() {
         let doc = Document {
             Span("")
                 .class("a", "b", "c")
+                .class(insert: "d")
                 .class(insert: "d")
         }
         let html = DocumentRenderer(minify: true).render(doc)


### PR DESCRIPTION
This proposal is predicated on the idea that space separated values inside the class attribute should be unique.

```html
<p class='valueA valueB valueC'>...<\p>
```

I have been running into situations where I build complex objects on top of simpler ones. And many times I can't be sure if the simple object has certain values already set. So there are two choices—check the simple object for that value before adding, or just add the one I need.

Checking takes extra time and code for every string, like an unnecessary two-step process.

And blindly adding introduces the possibility of duplicate values, which, depending on the number of them, can lead to very messy html.

And just fundamentally, if class values should be unique, they should be managed that way.

Instead of...

```swift
func `class`(add value: String?, _ condition: Bool = true) -> Self
```
How about...

```swift
func `class`(insert value: String?, _ condition: Bool = true) -> Self
```
And then treat the underlying String like a Set while manipulating it.

So when you want to add a value, you don't have to worry about whether it exists or not. And no duplications. Changing the parameter label to ```insert``` reinforces that notion.

Also, I added a version that takes variadic Optionals.

```swift
func `class`(insert values: String?..., if condition: Bool = true) -> Self
```

I use it in my own code and find it extremely flexible. You can write...

```Swift
tag.class(insert: v)
tag.class(insert: optionalV)

tag.class(insert: v, if: condition)
tag.class(insert: optionalV, if: condition)

tag.class(insert: v, optionalV)

tag.class(insert: v, optionalV, if: condition)

tag.class(insert: v, optionalV, "anything", if: condition)
```

The only rub is having to put a parameter label where there was none. I chose ```if``` to indicate the logic.

I won't take it personally if this seems a bit too far out on a limb. But it's really flexible and terse when you need to constantly add a few values here or there without the ```[ ]```. And it keeps with the theme of every other function that accepts an optional value and a Bool condition.

I also changed...
```swift
func `class`(insert values: [String], _ condition: Bool = true) -> Self
```
...to take an optional array. Again more flexibility and keeps with the theme of every other func. But I understand if it's a bridge too far.
```swift
func `class`(insert values: [String]?, _ condition: Bool = true) -> Self
```

Lastly, I added a ```guard``` condition in...

```swift
func `class`(remove values: [String], _ condition: Bool = true) -> Self
```
I could be wrong, but I think the ```class``` attribute can be deleted even if the ```condition``` is ```false```

I commented on my lines of code as well. Hopefully that makes things more clear.