### PR TITLE
Button and Input attribute formmethod must be Method, not EncType

### DIFF
--- a/Sources/SwiftHtml/Tags/Button.swift
+++ b/Sources/SwiftHtml/Tags/Button.swift
@@ -53,7 +53,7 @@ public extension Button {
     }
     
     /// Specifies how to send the form-data (which HTTP method to use). Only for type="submit"
-    func formmethod(_ value: Enctype = .urlencoded) -> Self {
+    func formmethod(_ value: Method = .get) -> Self {
         attribute("formmethod", value.rawValue)
     }
     

--- a/Sources/SwiftHtml/Tags/Input.swift
+++ b/Sources/SwiftHtml/Tags/Input.swift
@@ -101,7 +101,7 @@ public extension Input {
     }
     
     /// Defines the HTTP method for sending data to the action URL (for type="submit" and type="image")
-    func formmethod(_ value: Enctype = .urlencoded) -> Self {
+    func formmethod(_ value: Method = .get) -> Self {
         attribute("formmethod", value.rawValue)
     }
     


### PR DESCRIPTION
Updated and tested the changes on my local machine, then pushed them to my fork.