### PR TITLE
Make the Tag render function public

### DIFF
--- a/Sources/SwiftSgml/DocumentRenderer.swift
+++ b/Sources/SwiftSgml/DocumentRenderer.swift
@@ -36,7 +36,7 @@ public struct DocumentRenderer {
         }
     }
 
-    private func render(tag: Tag, level: Int = 0) -> String {
+    public func render(tag: Tag, level: Int = 0) -> String {
         let spaces = String(repeating: " ", count: level * indent)
         switch tag.node.type {
         case .standard:


### PR DESCRIPTION
I have a case where I need access to render(render: Tag, level: Int = 0) -> String