### PR TITLE
Treat class attribute like Set<String> instead of Array<String>

### DIFF
--- a/Sources/SwiftSgml/Tag.swift
+++ b/Sources/SwiftSgml/Tag.swift
@@ -83,10 +83,10 @@ open class Tag {
         guard var value = value, condition else { return self }
         /// insure integrity of class value by filtering empty and duplicate strings
         if key == "class" {
-            let slugs = value
+            let substrings = value
                 .split(separator: " ")
                 .filter{ !$0.isEmpty }
-            value = Set(slugs).joined(separator: " ")
+            value = Set(substrings).joined(separator: " ")
         }
         node.upsert(Attribute(key: key, value: value))
         return self

--- a/Sources/SwiftSgml/Tag.swift
+++ b/Sources/SwiftSgml/Tag.swift
@@ -80,9 +80,15 @@ open class Tag {
     /// add a new attribute with a given value if the condition is true
     @discardableResult
     public func attribute(_ key: String, _ value: String?, _ condition: Bool = true) -> Self {
-        if let value = value, condition {
-            node.upsert(Attribute(key: key, value: value))
+        guard var value = value, condition else { return self }
+        /// insure integrity of class value by filtering empty and duplicate strings
+        if key == "class" {
+            let slugs = value
+                .split(separator: " ")
+                .filter{ !$0.isEmpty }
+            value = Set(slugs).joined(separator: " ")
         }
+        node.upsert(Attribute(key: key, value: value))
         return self
     }
 

--- a/Tests/SwiftHtmlTests/SwiftHtmlTests.swift
+++ b/Tests/SwiftHtmlTests/SwiftHtmlTests.swift
@@ -31,55 +31,76 @@ final class SwiftHtmlTests: XCTestCase {
         XCTAssertEqual(#"<div some-key="some-value"><span>a</span><span>b</span></div>"#, html)
     }
     
+    func testClassAttributeWithSpaces() {
+        let span = Span("").attribute("class", "   a  b b   c")
+        XCTAssertTrue(span.classes.count == 3)
+        XCTAssertTrue(span.classes.contains("a"))
+        XCTAssertTrue(span.classes.contains("b"))
+        XCTAssertTrue(span.classes.contains("c"))
+    }
+    
     func testClassAttribute() {
-        let doc = Document {
-            Span("").class("a", "b", "", "b", "c")
-        }
-        let html = DocumentRenderer(minify: true).render(doc)
-        XCTAssertEqual(#"<span class="a b b c"></span>"#, html)
+        let span = Span("").class("a", "b", "", "b", "c")
+        XCTAssertTrue(span.classes.count == 3)
+        XCTAssertTrue(span.classes.contains("a"))
+        XCTAssertTrue(span.classes.contains("b"))
+        XCTAssertTrue(span.classes.contains("c"))
+    }
+    
+    func testEmptyClassAttribute() {
+        let span = Span("")
+            .class("a", "b", "c")
+            .class("")
+        XCTAssertTrue(span.classes.count == 0)
+    }
+    
+    func testSetNilClass() {
+        let span = Span("")
+            .class("a", "b", "c")
+            .class(nil)
+        XCTAssertTrue(span.classes.count == 3)
     }
     
     func testMultipleClasses() {
-        let doc = Document {
-            Span("")
-                .class("a", "b", "c")
-                .class("d", "e", "f")
-        }
-        let html = DocumentRenderer(minify: true).render(doc)
-        XCTAssertEqual(#"<span class="d e f"></span>"#, html)
+        let span = Span("")
+            .class("a", "b", "c")
+            .class("d", "e", "f")
+        XCTAssertTrue(span.classes.count == 3)
+        XCTAssertTrue(span.classes.contains("d"))
+        XCTAssertTrue(span.classes.contains("e"))
+        XCTAssertTrue(span.classes.contains("f"))
     }
     
     func testClassManipulation() {
-        let doc = Document {
-            Span("")
-                .class("a", "b", "c")
-                .class(add: ["d", "e", "f"])
-                .class(add: "b", true)
-                .class(remove: ["b", "c", "d"])
-                .class(remove: "e", true)
-        }
-        let html = DocumentRenderer(minify: true).render(doc)
-        XCTAssertEqual(#"<span class="a f"></span>"#, html)
+        let span = Span("")
+            .class("a", "b", "c")
+            .class(insert: ["d", "e", "f"])
+            .class(insert: "b", true)
+            .class(remove: ["b", "c", "d"])
+            .class(remove: "e", true)
+        XCTAssertTrue(span.classes.count == 2)
+        XCTAssertTrue(span.classes.contains("a"))
+        XCTAssertTrue(span.classes.contains("f"))
     }
     
-    func testAddClass() {
-        let doc = Document {
-            Span("")
-                .class("a", "b", "c")
-                .class(add: "d")
-        }
-        let html = DocumentRenderer(minify: true).render(doc)
-        XCTAssertEqual(#"<span class="a b c d"></span>"#, html)
+    func testInsertClass() {
+        let span = Span("")
+            .class("a", "b", "c")
+            .class(insert: "d")
+        XCTAssertTrue(span.classes.count == 4)
+        XCTAssertTrue(span.classes.contains("a"))
+        XCTAssertTrue(span.classes.contains("b"))
+        XCTAssertTrue(span.classes.contains("c"))
+        XCTAssertTrue(span.classes.contains("d"))
     }
     
     func testRemoveClass() {
-        let doc = Document {
-            Span("")
-                .class("a", "b", "c")
-                .class(remove: "b")
-        }
-        let html = DocumentRenderer(minify: true).render(doc)
-        XCTAssertEqual(#"<span class="a c"></span>"#, html)
+        let span = Span("")
+            .class("a", "b", "c")
+            .class(remove: "b")
+        XCTAssertTrue(span.classes.count == 2)
+        XCTAssertTrue(span.classes.contains("a"))
+        XCTAssertTrue(span.classes.contains("c"))
     }
     
     func testRemoveLastClass() {
@@ -93,23 +114,34 @@ final class SwiftHtmlTests: XCTestCase {
     }
     
     func testToggleAddClass() {
-        let doc = Document {
-            Span("")
-                .class("a", "b", "c")
-                .class(toggle: "d")
-        }
-        let html = DocumentRenderer(minify: true).render(doc)
-        XCTAssertEqual(#"<span class="a b c d"></span>"#, html)
+        let span = Span("")
+            .class("a", "b", "c")
+            .class(toggle: "d")
+        XCTAssertTrue(span.classes.count == 4)
+        XCTAssertTrue(span.classes.contains("a"))
+        XCTAssertTrue(span.classes.contains("b"))
+        XCTAssertTrue(span.classes.contains("c"))
+        XCTAssertTrue(span.classes.contains("d"))
     }
     
     func testToggleRemoveClass() {
-        let doc = Document {
-            Span("")
-                .class("a", "b", "c")
-                .class(toggle: "b")
-        }
-        let html = DocumentRenderer(minify: true).render(doc)
-        XCTAssertEqual(#"<span class="a c"></span>"#, html)
+        let span = Span("")
+            .class("a", "b", "c")
+            .class(toggle: "b")
+        XCTAssertTrue(span.classes.count == 2)
+        XCTAssertTrue(span.classes.contains("a"))
+        XCTAssertTrue(span.classes.contains("c"))
+    }
+    
+    func testIntersectClasses() {
+        let classes: Set<String> = [ "a", "b", "c" ]
+        let otherClasses: Set<String> = [ "b", "c", "d" ]
+        let span = Span("")
+            .class(classes)
+            .class(intersect: otherClasses)
+        XCTAssertTrue(span.classes.count == 2)
+        XCTAssertTrue(span.classes.contains("b"))
+        XCTAssertTrue(span.classes.contains("c"))
     }
     
     func testSetEmptyStyle() {
@@ -185,7 +217,7 @@ final class SwiftHtmlTests: XCTestCase {
                                 H1("Lorem ipsum")
                                     .class("red")
                                 P("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla pretium leo eu euismod porta.")
-                                    .class(["green", "blue"])
+                                    .class(["blue", "green"])
                                     .spellcheck(false)
                             }
                             A("Hello Swift HTML DSL!")
@@ -203,8 +235,33 @@ final class SwiftHtmlTests: XCTestCase {
                 }
             }
         }
-
-        XCTAssertEqual(DocumentRenderer().render(doc), """
+        
+        let blueGreenClasses = """
+                            <!DOCTYPE html>
+                            <html>
+                                <head>
+                                    <title>Hello Swift DSL</title>
+                                    <meta charset="utf-8">
+                                    <meta name="viewport" content="width=device-width, initial-scale=1">
+                                    <link rel="stylesheet" href="./css/style.css">
+                                </head>
+                                <body>
+                                    <main class="container">
+                                        <div>
+                                            <section>
+                                                <img src="./images/swift.png" alt="Swift Logo" title="Picture of the Swift Logo">
+                                                <h1 class="red">Lorem ipsum</h1>
+                                                <p class="blue green" spellcheck="false">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla pretium leo eu euismod porta.</p>
+                                            </section>
+                                            <a href="https://swift.org" target="_blank" download>Hello Swift HTML DSL!</a>
+                                            <abbr title="World Health Organization">WHO</abbr>
+                                        </div>
+                                    </main>
+                                    <script src="./javascript/main.js"></script>
+                                </body>
+                            </html>
+                            """
+        let greenBlueClasses = """
                             <!DOCTYPE html>
                             <html>
                                 <head>
@@ -228,6 +285,8 @@ final class SwiftHtmlTests: XCTestCase {
                                     <script src="./javascript/main.js"></script>
                                 </body>
                             </html>
-                            """)
+                            """
+        let html = DocumentRenderer().render(doc)
+        XCTAssertTrue(html == blueGreenClasses || html == greenBlueClasses)
     }
 }


### PR DESCRIPTION
These changes are primarily about trying to guarantee the format of the class attribute value is always consistent. And without empty or duplicate substrings. Regardless of whether it is set as a string literal in .attribute(...) or via the class(...) functions. And the best way to accomplish this is by treating the underlying attribute value like a Set<String> rather than an Array<String>

As an added benefit, the class attribute can handle .union(...), .subtraction(...) and .intersection(...) This is especially helpful when trying to eliminate lots of possible classes without having to interrogate for each one. It takes very little code to create a large Set and just subtract it.