### PR TITLE
init Tag with Node

### DIFF
--- a/Sources/SwiftSgml/Tag.swift
+++ b/Sources/SwiftSgml/Tag.swift
@@ -16,10 +16,15 @@ open class Tag {
         Node(type: .standard, name: String(describing: self).lowercased())
     }
 
-    /// initialize a new Tag with child tags
-    public init(_ children: [Tag] = []) {
-        self.node = Self.createNode()
+    public init(node: Node, children: [Tag] = []) {
+        self.node = node
         self.children = children
+    }
+
+    /// initialize a new Tag with child tags
+    public convenience init(_ children: [Tag] = []) {
+        self.init(node: Self.createNode(), 
+                  children: children)
     }
 
     /// initialize a new Tag with a single child tag


### PR DESCRIPTION
`class func createNode()` is not flexible enough.

A subclass overriding it can only be one kind of `<name>`

`init(node: Node)` allows for multiple kinds of `<name>`

A subclass can determine the best one based on initial conditions.

For example...

```
class MyText: Tag {
     convenience init(_ value: String,
                      isBold: Bool = false) {
          let node = Node(type: .standard,
                          name: isBold ? "b" : "p", 
                          contents: value)
          self.init(node: Node)
     }
}
```

And nothing else related to the way `Tag` is initialized has to change.