### PR TITLE
Fix Tag composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,9 @@ struct ListComponent: TagRepresentable {
     @TagBuilder
     func build() -> Tag {
         Ul {
-            items.map { Li($0) }
+            for item in items {
+                Li(item)
+            }
         }
     }
 }
@@ -217,22 +219,12 @@ This way it is also possible to extend the `TagBuilder` to support the new proto
 ```swift
 extension TagBuilder {
 
-    static func buildExpression(_ expression: TagRepresentable) -> Tag {
-        expression.build()
+    static func buildExpression(_ expression: Tag) -> Tag {
+        expression
     }
     
-    static func buildExpression(_ expression: TagRepresentable) -> [Tag] {
-        [expression.build()]
-    }
-
-    static func buildExpression(_ expression: [TagRepresentable]) -> [Tag] {
-        expression.map { $0.build() }
-    }
-
-    static func buildExpression(_ expression: [TagRepresentable]) -> Tag {
-        GroupTag {
-            expression.map { $0.build() }
-        }
+    static func buildExpression(_ expression: TagRepresentable) -> Tag {
+        expression.build()
     }
 }
 ```

--- a/Tests/SwiftHtmlTests/SwiftHtmlTests.swift
+++ b/Tests/SwiftHtmlTests/SwiftHtmlTests.swift
@@ -227,12 +227,12 @@ final class SwiftHtmlTests: XCTestCase {
 
         let doc = Document {
             Div {
-                values.map { item -> Tag in
-                    GroupTag {
-                        H1(item)
-                        P(item)
-                    }
-                }
+				for item in values {
+					GroupTag {
+						H1(item)
+						P(item)
+					}
+				}
             }
         }
 

--- a/Tests/SwiftHtmlTests/TagCompositionTests.swift
+++ b/Tests/SwiftHtmlTests/TagCompositionTests.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  TagCompositionTests.swift
+//  SwiftHtmlTests
 //
 //  Created by Tibor Bodecs on 2022. 02. 16..
 //
@@ -8,126 +8,135 @@
 import XCTest
 @testable import SwiftHtml
 
-//protocol TagRepresentable {
-//
-//    func build() -> Tag
-//}
-//
-//extension TagBuilder {
-//
-//    static func buildExpression(_ expression: TagRepresentable) -> Tag {
-//        expression.build()
-//    }
-//    
-//    static func buildExpression(_ expression: TagRepresentable) -> [Tag] {
-//        [expression.build()]
-//    }
-//
-//    static func buildExpression(_ expression: [TagRepresentable]) -> [Tag] {
-//        expression.map { $0.build() }
-//    }
-//
-//    static func buildExpression(_ expression: [TagRepresentable]) -> Tag {
-//        GroupTag {
-//            expression.map { $0.build() }
-//        }
-//    }
-//}
-//
-//struct ListComponent: TagRepresentable {
-//
-//    let items: [String]
-//    
-//    init(_ items: [String]) {
-//        self.items = items
-//    }
-//
-//    @TagBuilder
-//    func build() -> Tag {
-//        Ul {
-//            items.map { Li($0) }
-//        }
-//    }
-//}
-//
-//
-//final class TagCompositionTests: XCTestCase {
-//
-//    func testListComponentBuild() {
-//        let doc = Document {
-//            ListComponent(["a", "b", "c"]).build()
-//        }
-//
-//        let html = """
-//                            <ul>
-//                                <li>a</li>
-//                                <li>b</li>
-//                                <li>c</li>
-//                            </ul>
-//                            """
-//    }
-//    
-//    func testListComponent() {
-//        let doc = Document {
-//            ListComponent(["a", "b", "c"])
-//        }
-//
-//        let html = """
-//                            <ul>
-//                                <li>a</li>
-//                                <li>b</li>
-//                                <li>c</li>
-//                            </ul>
-//                            """
-//    }
-//    
-//    func testListComponentAndTags() {
-//        let doc = Document {
-//            H1("foo")
-//            ListComponent(["a", "b", "c"])
-//        }
-//
-//        let html = """
-//                            <h1>foo</h1>
-//                            <ul>
-//                                <li>a</li>
-//                                <li>b</li>
-//                                <li>c</li>
-//                            </ul>
-//                            """
-//    }
-//    
-//    func testListComponentAndGroupTag() {
-//        let doc = Document {
-//            H1("foo")
-//            ["1", "2", "3"].map { value -> Tag in
-//                GroupTag {
-//                    H2(value)
-//                    ListComponent(["a", "b", "c"])
-//                }
-//            }
-//        }
-//
-//        let html = """
-//                            <h1>foo</h1>
-//                            <h2>1</h2>
-//                            <ul>
-//                                <li>a</li>
-//                                <li>b</li>
-//                                <li>c</li>
-//                            </ul>
-//                            <h2>2</h2>
-//                            <ul>
-//                                <li>a</li>
-//                                <li>b</li>
-//                                <li>c</li>
-//                            </ul>
-//                            <h2>3</h2>
-//                            <ul>
-//                                <li>a</li>
-//                                <li>b</li>
-//                                <li>c</li>
-//                            </ul>
-//                            """
-//    }
-//}
+protocol TagRepresentable {
+    
+    func build() -> Tag
+}
+
+extension TagBuilder {
+    
+    static func buildExpression(_ expression: Tag) -> Tag {
+        expression
+    }
+    
+    static func buildExpression(_ expression: TagRepresentable) -> Tag {
+        expression.build()
+    }
+}
+
+struct ListComponent: TagRepresentable {
+    
+    let items: [String]
+    
+    init(_ items: [String]) {
+        self.items = items
+    }
+    
+    @TagBuilder
+    func build() -> Tag {
+        Ul {
+            for item in items {
+                Li(item)
+            }
+        }
+    }
+}
+
+
+final class TagCompositionTests: XCTestCase {
+    private let renderer = DocumentRenderer(minify: false)
+    
+    func testListComponentBuild() {
+        let doc = Document {
+            ListComponent(["a", "b", "c"]).build()
+        }
+        
+        let producedHTML = renderer.render(doc)
+        
+        let referenceHTML = """
+        <ul>
+            <li>a</li>
+            <li>b</li>
+            <li>c</li>
+        </ul>
+        """
+        
+        XCTAssertEqual(producedHTML, referenceHTML)
+    }
+    
+    func testListComponent() {
+        let doc = Document {
+            ListComponent(["a", "b", "c"])
+        }
+        
+        let producedHTML = renderer.render(doc)
+        
+        let referenceHTML = """
+        <ul>
+            <li>a</li>
+            <li>b</li>
+            <li>c</li>
+        </ul>
+        """
+        
+        XCTAssertEqual(producedHTML, referenceHTML)
+    }
+    
+    func testListComponentAndTags() {
+        let doc = Document {
+            H1("foo")
+            ListComponent(["a", "b", "c"])
+        }
+        
+        let producedHTML = renderer.render(doc)
+        
+        let referenceHTML = """
+        <h1>foo</h1>
+        <ul>
+            <li>a</li>
+            <li>b</li>
+            <li>c</li>
+        </ul>
+        """
+        
+        XCTAssertEqual(producedHTML, referenceHTML)
+    }
+    
+    func testListComponentAndGroupTag() {
+        let doc = Document {
+            H1("foo")
+            for value in ["1", "2", "3"] {
+                GroupTag {
+                    H2(value)
+                    ListComponent(["a", "b", "c"])
+                }
+            }
+        }
+        
+        let producedHTML = renderer.render(doc)
+        
+        let referenceHTML = """
+        <h1>foo</h1>
+        <h2>1</h2>
+        <ul>
+            <li>a</li>
+            <li>b</li>
+            <li>c</li>
+        </ul>
+        <h2>2</h2>
+        <ul>
+            <li>a</li>
+            <li>b</li>
+            <li>c</li>
+        </ul>
+        <h2>3</h2>
+        <ul>
+            <li>a</li>
+            <li>b</li>
+            <li>c</li>
+        </ul>
+        """
+        
+        XCTAssertEqual(producedHTML, referenceHTML)
+    }
+}

--- a/Tests/SwiftHtmlTests/Tags/FormTagTests.swift
+++ b/Tests/SwiftHtmlTests/Tags/FormTagTests.swift
@@ -14,7 +14,9 @@ final class FormTagTests: XCTestCase {
         let items = ["a", "b", "c"]
         let doc = Document {
             Form {
-                items.map { P($0) }
+				for item in items {
+					P(item)
+				}
             }
         }
         XCTAssertEqual(DocumentRenderer(minify: true).render(doc), #"<form><p>a</p><p>b</p><p>c</p></form>"#)


### PR DESCRIPTION
The previous approach relied on invalid type inference. This has been fixed in Swift 5.8 ([Swift Evolution](https://forums.swift.org/t/improved-result-builder-implementation-in-swift-5-8/63192)).
I have updated the README and TagCompositionTests to use the new system.