### PR TITLE
Improve composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ public extension Guid {
 
 There are other built-in type-safe attribute modifiers available on tags.
 
- 
+
 ## Composing tags
 
 You can come up with your own `Tag` composition system by introducing a new protocol.
@@ -190,6 +190,7 @@ You can come up with your own `Tag` composition system by introducing a new prot
 ```swift
 protocol TagRepresentable {
 
+    @TagBuilder
     func build() -> Tag
 }
 
@@ -201,7 +202,6 @@ struct ListComponent: TagRepresentable {
         self.items = items
     }
 
-    @TagBuilder
     func build() -> Tag {
         Ul {
             for item in items {

--- a/Tests/SwiftHtmlTests/TagCompositionTests.swift
+++ b/Tests/SwiftHtmlTests/TagCompositionTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import SwiftHtml
 
 protocol TagRepresentable {
-    
+    @TagBuilder
     func build() -> Tag
 }
 
@@ -32,7 +32,6 @@ struct ListComponent: TagRepresentable {
         self.items = items
     }
     
-    @TagBuilder
     func build() -> Tag {
         Ul {
             for item in items {


### PR DESCRIPTION
By moving the @TagBuilder property wrapper to the protocol, we don't need to write it every time.