### PR TITLE
Allow self closing tags

### DIFF
--- a/Sources/SwiftSgml/DocumentRenderer.swift
+++ b/Sources/SwiftSgml/DocumentRenderer.swift
@@ -10,11 +10,13 @@ public struct DocumentRenderer {
     private let newline: String
     public let minify: Bool
     public let indent: Int
-    
-    public init(minify: Bool = false, indent: Int = 4) {
+    public let selfClose: Bool
+
+    public init(minify: Bool = false, indent: Int = 4, selfClose: Bool = false) {
         self.minify = minify
         self.indent = minify ? 0 : indent
         self.newline = minify ? "" : "\n"
+        self.selfClose = selfClose
     }
 
     public func render(_ document: Document) -> String {
@@ -44,7 +46,11 @@ public struct DocumentRenderer {
         case .comment:
             return spaces + "<!-- " + (tag.node.contents ?? "") + " -->"
         case .empty:
-            return spaces + renderOpening(tag)
+            if selfClose {
+                return spaces + renderSelfClosing(tag)
+            } else {
+                return spaces + renderOpening(tag)
+            }
         case .group:
             var contents = ""
             if let rawValue = tag.node.contents {
@@ -71,7 +77,11 @@ public struct DocumentRenderer {
     private func renderOpening(_ tag: Tag) -> String {
         return "<" + tag.node.name! + (tag.node.attributes.isEmpty ? "" : " ") + renderAttributes(tag.node.attributes) + ">"
     }
-    
+
+    private func renderSelfClosing(_ tag: Tag) -> String {
+        return "<" + tag.node.name! + (tag.node.attributes.isEmpty ? "" : " ") + renderAttributes(tag.node.attributes) + " />"
+    }
+
     private func renderClosing(_ tag: Tag) -> String {
         "</" + tag.node.name! + ">"
     }

--- a/Sources/SwiftSgml/Node.swift
+++ b/Sources/SwiftSgml/Node.swift
@@ -13,9 +13,8 @@ public struct Node {
         case standard     // <div>  </div>
         /// comment tag
         case comment      // <!--   -->
-        // @TODO: force close tags? <br> vs <br/>
         /// non-container tags
-        case empty        // <br>
+        case empty        // <br/>
         /// invisible node for grouping other nodes
         case group    // *invisible group*<h1>lorem</h1><p>ipsum</p>*invisible group*
     }

--- a/Tests/SwiftHtmlTests/Tags/BrTagTests.swift
+++ b/Tests/SwiftHtmlTests/Tags/BrTagTests.swift
@@ -16,6 +16,6 @@ final class BrTagTests: XCTestCase {
             Br()
         }
         XCTAssertEqual(DocumentRenderer(minify: true).render(doc), #"<br>"#)
+        XCTAssertEqual(DocumentRenderer(minify: true, selfClose: true).render(doc), #"<br />"#)
     }
-
 }

--- a/Tests/SwiftHtmlTests/Tags/InputTagTests.swift
+++ b/Tests/SwiftHtmlTests/Tags/InputTagTests.swift
@@ -20,6 +20,9 @@ final class InputTagTests: XCTestCase {
         XCTAssertEqual(DocumentRenderer().render(doc), """
                             <input type="checkbox" checked>
                             """)
+        XCTAssertEqual(DocumentRenderer(selfClose: true).render(doc), """
+                            <input type="checkbox" checked />
+                            """)
     }
     
     func testUncheckedInput() {
@@ -35,6 +38,9 @@ final class InputTagTests: XCTestCase {
         XCTAssertEqual(DocumentRenderer().render(doc), """
                             <input type="checkbox">
                             """)
+        XCTAssertEqual(DocumentRenderer(selfClose: true).render(doc), """
+                            <input type="checkbox" />
+                            """)
     }
     
     func testKey() {
@@ -46,6 +52,9 @@ final class InputTagTests: XCTestCase {
 
         XCTAssertEqual(DocumentRenderer().render(doc), """
                             <input type="text" id="email" name="email">
+                            """)
+        XCTAssertEqual(DocumentRenderer(selfClose: true).render(doc), """
+                            <input type="text" id="email" name="email" />
                             """)
     }
    

--- a/Tests/SwiftHtmlTests/Tags/LinkTagTests.swift
+++ b/Tests/SwiftHtmlTests/Tags/LinkTagTests.swift
@@ -22,8 +22,11 @@ final class LinkTagTests: XCTestCase {
                 ])
                 .href("/img/apple/splash/1136x640.png")
         }
-        let html = DocumentRenderer(minify: true).render(doc)
+        var html = DocumentRenderer(minify: true).render(doc)
         XCTAssertEqual(#"<link rel="apple-touch-startup-image" media="screen and (device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/img/apple/splash/1136x640.png">"#, html)
+
+        html = DocumentRenderer(minify: true, selfClose: true).render(doc)
+        XCTAssertEqual(#"<link rel="apple-touch-startup-image" media="screen and (device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/img/apple/splash/1136x640.png" />"#, html)
     }
     
     func testIntegrity() {
@@ -34,8 +37,11 @@ final class LinkTagTests: XCTestCase {
                 .crossorigin(.anonymous)
             
         }
-        let html = DocumentRenderer(minify: true).render(doc)
+        var html = DocumentRenderer(minify: true).render(doc)
         XCTAssertEqual(#"<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">"#, html)
+
+        html = DocumentRenderer(minify: true, selfClose: true).render(doc)
+        XCTAssertEqual(#"<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous" />"#, html)
     }
     
 

--- a/Tests/SwiftHtmlTests/Tags/MetaTagTests.swift
+++ b/Tests/SwiftHtmlTests/Tags/MetaTagTests.swift
@@ -16,8 +16,11 @@ final class MetaTagTests: XCTestCase {
                 .name(.colorScheme)
                 .content("light dark")
         }
-        let html = DocumentRenderer(minify: true).render(doc)
+        var html = DocumentRenderer(minify: true).render(doc)
         XCTAssertEqual(#"<meta name="color-scheme" content="light dark">"#, html)
+
+        html = DocumentRenderer(minify: true, selfClose: true).render(doc)
+        XCTAssertEqual(#"<meta name="color-scheme" content="light dark" />"#, html)
     }
     
     func testMediaColorScheme() {
@@ -27,8 +30,11 @@ final class MetaTagTests: XCTestCase {
                 .content("#fff")
                 .media(.prefersColorScheme(.light))
         }
-        let html = DocumentRenderer(minify: true).render(doc)
+        var html = DocumentRenderer(minify: true).render(doc)
         XCTAssertEqual(##"<meta name="theme-color" content="#fff" media="(prefers-color-scheme: light)">"##, html)
+
+        html = DocumentRenderer(minify: true, selfClose: true).render(doc)
+        XCTAssertEqual(##"<meta name="theme-color" content="#fff" media="(prefers-color-scheme: light)" />"##, html)
     }
     
     func testAppleStatusBarStyle() {
@@ -37,8 +43,11 @@ final class MetaTagTests: XCTestCase {
                 .name(.appleMobileWebAppStatusBarStyle)
                 .content("default")
         }
-        let html = DocumentRenderer(minify: true).render(doc)
+        var html = DocumentRenderer(minify: true).render(doc)
         XCTAssertEqual(##"<meta name="apple-mobile-web-app-status-bar-style" content="default">"##, html)
+
+        html = DocumentRenderer(minify: true, selfClose: true).render(doc)
+        XCTAssertEqual(##"<meta name="apple-mobile-web-app-status-bar-style" content="default" />"##, html)
     }
 
 }

--- a/Tests/SwiftHtmlTests/Tags/SourceTagTests.swift
+++ b/Tests/SwiftHtmlTests/Tags/SourceTagTests.swift
@@ -16,8 +16,11 @@ final class SourceTagTests: XCTestCase {
                 .srcset("img.png")
                 .media([.prefersColorScheme(.dark)])
         }
-        let html = DocumentRenderer(minify: true).render(doc)
+        var html = DocumentRenderer(minify: true).render(doc)
         XCTAssertEqual(#"<source srcset="img.png" media="(prefers-color-scheme: dark)">"#, html)
+
+        html = DocumentRenderer(minify: true, selfClose: true).render(doc)
+        XCTAssertEqual(#"<source srcset="img.png" media="(prefers-color-scheme: dark)" />"#, html)
     }
     
    


### PR DESCRIPTION
## Summary

In html5 tags are not required to be self closed, although it's not a problem and the browser will ignore that. For xml and xhtml generation it is required.

This implements a new option `selfClose` on `DocumentRenderer` which by default is `false` to avoid polluting most uses cases and any API changes.

Please, let me know if you have better naming for things...

#### Demo
Default:
```swift
<input type="checkbox" checked>
```

With `selfClose`:
```swift
<input type="checkbox" checked />
```
